### PR TITLE
Hot Fix missing assembly Revit 2025

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -361,3 +361,4 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
+.idea

--- a/revit-mcp-plugin/revit-mcp-plugin.csproj
+++ b/revit-mcp-plugin/revit-mcp-plugin.csproj
@@ -1,63 +1,96 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <OutputType>Library</OutputType>
-    <RootNamespace>revit_mcp_plugin</RootNamespace>
-    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <UseWindowsForms>true</UseWindowsForms>
-    <UseWPF>true</UseWPF>
-    <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
-	  <Configurations>Debug R20;Debug R21;Debug R22;Debug R24;Debug R25;Release R20;Release R21;Release R22;Release R23;Release R24;Release R25;Debug R23</Configurations>
-    <PlatformTarget>x64</PlatformTarget>
-	  <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-  </PropertyGroup>
+    <PropertyGroup>
+        <OutputType>Library</OutputType>
+        <RootNamespace>revit_mcp_plugin</RootNamespace>
+        <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+        <UseWindowsForms>true</UseWindowsForms>
+        <UseWPF>true</UseWPF>
+        <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
+        <Configurations>Debug R20;Debug R21;Debug R22;Debug R24;Debug R25;Release R20;Release R21;Release R22;Release R23;Release R24;Release R25;Debug R23</Configurations>
+        <PlatformTarget>x64</PlatformTarget>
+        <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+        
+    </PropertyGroup>
 
-	<PropertyGroup Condition="$(Configuration.Contains('R20'))">
-		<RevitVersion>2020</RevitVersion>
-		<TargetFramework>net48</TargetFramework>
-		<OutputPath>bin\$(Configuration.Split(' ')[0])\$(RevitVersion)\</OutputPath>
-	</PropertyGroup>
-	<PropertyGroup Condition="$(Configuration.Contains('R21'))">
-		<RevitVersion>2021</RevitVersion>
-		<TargetFramework>net48</TargetFramework>
-		<OutputPath>bin\$(Configuration.Split(' ')[0])\$(RevitVersion)\</OutputPath>
-	</PropertyGroup>
-	<PropertyGroup Condition="$(Configuration.Contains('R22'))">
-		<RevitVersion>2022</RevitVersion>
-		<TargetFramework>net48</TargetFramework>
-		<OutputPath>bin\$(Configuration.Split(' ')[0])\$(RevitVersion)\</OutputPath>
-	</PropertyGroup>
-	<PropertyGroup Condition="$(Configuration.Contains('R23'))">
-		<RevitVersion>2023</RevitVersion>
-		<TargetFramework>net48</TargetFramework>
-		<OutputPath>bin\$(Configuration.Split(' ')[0])\$(RevitVersion)\</OutputPath>
-	</PropertyGroup>
-	<PropertyGroup Condition="$(Configuration.Contains('R24'))">
-		<RevitVersion>2024</RevitVersion>
-		<TargetFramework>net48</TargetFramework>
-		<OutputPath>bin\$(Configuration.Split(' ')[0])\$(RevitVersion)\</OutputPath>
-	</PropertyGroup>
-	<PropertyGroup Condition="$(Configuration.Contains('R25'))">
-		<RevitVersion>2025</RevitVersion>
-		<TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
-		<OutputPath>bin\$(Configuration.Split(' ')[0])\$(RevitVersion)\</OutputPath>
-	</PropertyGroup>
+    <PropertyGroup Condition="$(Configuration.Contains('R20'))">
+        <RevitVersion>2020</RevitVersion>
+        <TargetFramework>net48</TargetFramework>
+        <OutputPath>bin\$(Configuration.Split(' ')[0])\$(RevitVersion)\</OutputPath>
+    </PropertyGroup>
+    <PropertyGroup Condition="$(Configuration.Contains('R21'))">
+        <RevitVersion>2021</RevitVersion>
+        <TargetFramework>net48</TargetFramework>
+        <OutputPath>bin\$(Configuration.Split(' ')[0])\$(RevitVersion)\</OutputPath>
+    </PropertyGroup>
+    <PropertyGroup Condition="$(Configuration.Contains('R22'))">
+        <RevitVersion>2022</RevitVersion>
+        <TargetFramework>net48</TargetFramework>
+        <OutputPath>bin\$(Configuration.Split(' ')[0])\$(RevitVersion)\</OutputPath>
+    </PropertyGroup>
+    <PropertyGroup Condition="$(Configuration.Contains('R23'))">
+        <RevitVersion>2023</RevitVersion>
+        <TargetFramework>net48</TargetFramework>
+        <OutputPath>bin\$(Configuration.Split(' ')[0])\$(RevitVersion)\</OutputPath>
+    </PropertyGroup>
+    <PropertyGroup Condition="$(Configuration.Contains('R24'))">
+        <RevitVersion>2024</RevitVersion>
+        <TargetFramework>net48</TargetFramework>
+        <OutputPath>bin\$(Configuration.Split(' ')[0])\$(RevitVersion)\</OutputPath>
+    </PropertyGroup>
+    <PropertyGroup Condition="$(Configuration.Contains('R25'))">
+        <RevitVersion>2025</RevitVersion>
+        <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
+        <OutputPath>bin\$(Configuration.Split(' ')[0])\$(RevitVersion)\</OutputPath>
+        <EnableDynamicLoading>true</EnableDynamicLoading>
+    </PropertyGroup>
+    <PropertyGroup>
+        <StartAction>Program</StartAction>
+        <StartProgram>C:\Program Files\Autodesk\Revit $(RevitVersion)\Revit.exe</StartProgram>
+        <StartArguments>/language ENG</StartArguments>
+    </PropertyGroup>
+    <ItemGroup>
+        <PackageReference Include="Microsoft.CSharp" Version="4.7.0"/>
+        <PackageReference Include="Nice3point.Revit.Api.RevitAPI" Version="$(RevitVersion).*"/>
+        <PackageReference Include="Nice3point.Revit.Api.RevitAPIUI" Version="$(RevitVersion).*"/>
+        <PackageReference Include="RevitMCPSDK" Version="$(RevitVersion).*"/>
+        <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0"/>
+    </ItemGroup>
+    <ItemGroup>
+        <Resource Include="Core\Ressources\icon-16.png"/>
+        <Resource Include="Core\Ressources\icon-32.png"/>
+    </ItemGroup>
+    <ItemGroup>
+        <Resource Include="Core\Ressources\settings-16.png"/>
+        <Resource Include="Core\Ressources\settings-32.png"/>
+    </ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="Newtonsoft.Json" Version="13.0.3"/>
+    </ItemGroup>
+    <ItemGroup>
+        <None Update="revit-mcp.addin">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
+    </ItemGroup>
+    <Target Name="CopyFiles" AfterTargets="CoreBuild">
+        <ItemGroup>
+            <RootItem Include="$(ProjectDir)*.addin"/>
+            <AddinItem Include="$(TargetDir)*.dll"/>
+            <AddinItem Include="$(TargetDir)*.pdb"/>
+        </ItemGroup>
 
-   <ItemGroup>
-    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-		<PackageReference Include="Nice3point.Revit.Api.RevitAPI" Version="$(RevitVersion).*" />
-		<PackageReference Include="Nice3point.Revit.Api.RevitAPIUI" Version="$(RevitVersion).*" />
-    <PackageReference Include="RevitMCPSDK" Version="$(RevitVersion).*" />
-    <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
-  </ItemGroup>
-  <ItemGroup>
-    <Resource Include="Core\Ressources\icon-16.png" />
-    <Resource Include="Core\Ressources\icon-32.png" />
-  </ItemGroup>
-  <ItemGroup>
-    <Resource Include="Core\Ressources\settings-16.png" />
-    <Resource Include="Core\Ressources\settings-32.png" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-  </ItemGroup>
+        <PropertyGroup>
+            <RootDir>bin\AddIn $(RevitVersion) $(Configuration)\</RootDir>
+            <AddinDir>$(RootDir)$(RootNameSpace)\</AddinDir>
+        </PropertyGroup>
+
+        <Copy SourceFiles="@(RootItem)" DestinationFolder="$(RootDir)"/>
+        <Copy SourceFiles="@(AddinItem)" DestinationFolder="$(AddinDir)"/>
+
+        <ItemGroup>
+            <AddinFiles Include="$(RootDir)**\*.*"/>
+        </ItemGroup>
+        <Message Text="Copy files to Addin folder" Importance="high"/>
+        <Copy SourceFiles="@(AddinFiles)" DestinationFolder="$(AppData)\Autodesk\Revit\Addins\$(RevitVersion)\%(RecursiveDir)" Condition="$(Configuration.Contains('Debug'))"/>
+    </Target>
+
 </Project>

--- a/revit-mcp-plugin/revit-mcp.addin
+++ b/revit-mcp-plugin/revit-mcp.addin
@@ -2,7 +2,7 @@
 <RevitAddIns>
   <AddIn Type="Application">
     <Name>revit-mcp</Name>
-    <Assembly>revit-mcp-plugin.dll</Assembly>
+    <Assembly>revit_mcp_plugin/revit-mcp-plugin.dll</Assembly>
     <FullClassName>revit_mcp_plugin.Core.Application</FullClassName>
     <ClientId>090A4C8C-61DC-426D-87DF-E4BAE0F80EC1</ClientId>
     <VendorId>revit-mcp</VendorId>


### PR DESCRIPTION
1. Fix missing copy assembly revit 2025
2. Added .idea to .gitignore. Enhanced revit-mcp-plugin.csproj with improved build configuration, resource management, package references, and automated copying of output files to Revit Addins folder. Updated .addin file to reference the correct assembly path.

Related issue #12 